### PR TITLE
Fix minimum version of pack to follow existing instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ ubi extension.
    registry an easy way to do that is using
    `docker run -d -p 5000:5000 --restart=always --name registry registry:2`.
 1. Get a current version of pack and ensure it is on your path.
-   It should be at least version 0.28 or later. The releases are
+   It should be at least version v0.30.0-pre2 or later. The releases are
    available from [here](https://github.com/buildpacks/pack/releases).
 1. Clone the repository for this extension
 1. cd into the directory into which you have cloned the repository


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Update minimum pack version required. This should have been updated when we removed the
instructions to pull the run images manually.

## Use Cases
<!-- An explanation of the use cases your change enables -->
Existing instructions should work as listed.

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
