### PR TITLE
feat: switch to using ubi-base-stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 The Node.js Extension for
 [ubi](https://www.redhat.com/en/blog/introducing-red-hat-universal-base-image)
 allows builders to be created which build Node.js applications on top of
-Red Hat's Node. Node.js ubi containers. For example
+Red Hat's Node.js ubi containers. For example
 [ubi8/nodejs-16-minimal](https://catalog.redhat.com/software/containers/ubi8/nodejs-16-minimal/615aefd53f6014fa45ae1ae2).
 
 ## Integration
@@ -70,32 +70,10 @@ ubi extension.
        version = "0.0.1"
 
    [stack]
-     id = "ubi8-paketo"
-     build-image = "quay.io/midawson/ubi8-paketo-build"
-     run-image = "quay.io/midawson/ubi8-paketo-run"
+     id = "io.buildpacks.stacks.ubi8"
+     build-image = "paketocommunity/build-ubi-base"
+     run-image = "paketocommunity/run-ubi-base"
    ```
-
-   A stack requires a build-image and a run-image and the extension
-   requires a run image for each supported Node.js stream. We have made the
-   following images available for initial testing while we work on
-   building out the infrastruture to regularly build the required images:
-
-   - quay.io/midawson/ubi8-paketo-build
-   - quay.io/midawson/ubi8-paketo-run
-   - quay.io/midawson/ubi8-paketo-run-nodejs-18
-   - quay.io/midawson/ubi8-paketo-run-nodejs-16
-
-   The `ubi8-paketo-run-nodejs-XX` are simply the ubi8/nodejs-XX-minimal
-   images with the additional metadata and user/groups required by the
-   buildpacks spefication added. Overtime we plan to incorporate the
-   required chagnes into the ubi8/nodejs-XX-minimal images themselves.
-
-   The `ubi8-paketo-build` and `ubit-pakto-run` images are simply
-   the `ubi8/ubi` and `ubi8/ubi-minimal` images with the additional
-   metadata and user/groups required by the buildpacks spefication added.
-   There is an effort to remove the concept of stacks and, therefore,
-   over time the need for these containers with additional metadata will
-   fade.
 
    To create the builder:
 
@@ -124,7 +102,7 @@ ubi extension.
 
 ubi only supports the latest version of each Node.js stream
 currently available in the ubi version. At the time of writing
-ubi8 supports the Node.js 14, 16, and 18 streams. For example,
+ubi8 supports the Node.js 16, and 18 streams. For example,
 if the latest Node.js version for the 16.x stream in ubi8 is 16.10.1
 then that is your only option when requesting the Node.js 16.x stream.
 Therefore we suggest that you request the Node.js version such that it

--- a/extension.toml
+++ b/extension.toml
@@ -15,13 +15,13 @@ description = "This extension installs the appropriate nodejs runtime via dnf"
   [[metadata.dependencies]]
     id = "node"
     name = "Ubi Node Extension"
-    stacks = ["ubi8-paketo"]
-    source = "quay.io/midawson/ubi8-paketo-run-nodejs-18"
+    stacks = ["io.buildpacks.stacks.ubi8"]
+    source = "paketocommunity/run-nodejs-18-ubi-base"
     version = "18.1000"
 
   [[metadata.dependencies]]
     id = "node"
     name = "Ubi Node Extension"
-    stacks = ["ubi8-paketo"]
-    source = "quay.io/midawson/ubi8-paketo-run-nodejs-16"
+    stacks = ["io.buildpacks.stacks.ubi8"]
+    source = "paketocommunity/run-nodejs-18-ubi-base"
     version = "16.1000"

--- a/generate_test.go
+++ b/generate_test.go
@@ -80,13 +80,13 @@ RUN echo "CNB_STACK_ID: "`))
 		it("Should fill with properties the template/run.Dockerfile", func() {
 
 			RunDockerfileProps := RunDockerfileProps{
-				Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+				Source: "paketocommunity/run-nodejs-18-ubi-base",
 			}
 
 			output, err := ubinodejsextension.FillPropsToTemplate(RunDockerfileProps, runDockerfileTemplate)
 
 			Expect(err).NotTo(HaveOccurred())
-			Expect(output).To(Equal(`FROM paketo-buildpacks/ubi8-paketo-run-nodejs-18`))
+			Expect(output).To(Equal(`FROM paketocommunity/run-nodejs-18-ubi-base`))
 
 		})
 	})
@@ -185,7 +185,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -197,7 +197,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -209,7 +209,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -221,7 +221,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -233,7 +233,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -245,7 +245,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -257,7 +257,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -269,7 +269,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -281,7 +281,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -293,7 +293,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -305,7 +305,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -325,7 +325,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 					},
-					Stack: "ubi8-paketo",
+					Stack: "io.buildpacks.stacks.ubi8",
 				})
 
 				Expect(err).NotTo(HaveOccurred())
@@ -369,7 +369,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -381,7 +381,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 16,
@@ -393,7 +393,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -413,7 +413,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 					},
-					Stack: "ubi8-paketo",
+					Stack: "io.buildpacks.stacks.ubi8",
 				})
 
 				Expect(err).NotTo(HaveOccurred())
@@ -457,7 +457,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -469,7 +469,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						"version-source": "BP_NODE_VERSION",
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-18",
+						Source: "paketocommunity/run-nodejs-18-ubi-base",
 					},
 					BuildDockerfileProps:                 BuildDockerfileProps,
 					buildDockerfileExpectedNodejsVersion: 18,
@@ -489,7 +489,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 					},
-					Stack: "ubi8-paketo",
+					Stack: "io.buildpacks.stacks.ubi8",
 				})
 
 				Expect(err).NotTo(HaveOccurred())
@@ -587,7 +587,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 							},
 						},
 					},
-					Stack: "ubi8-paketo",
+					Stack: "io.buildpacks.stacks.ubi8",
 				})
 
 				Expect(err).To(HaveOccurred())
@@ -649,7 +649,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 				},
 				{
@@ -668,7 +668,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 				},
 				{
@@ -679,7 +679,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 						},
 					},
 					RunDockerfileProps: ubinodejsextension.RunDockerfileProps{
-						Source: "paketo-buildpacks/ubi8-paketo-run-nodejs-16",
+						Source: "paketocommunity/run-nodejs-16-ubi-base",
 					},
 				},
 			}
@@ -692,7 +692,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 					Plan: packit.BuildpackPlan{
 						Entries: tt.Entries,
 					},
-					Stack: "ubi8-paketo",
+					Stack: "io.buildpacks.stacks.ubi8",
 				})
 
 				Expect(err).NotTo(HaveOccurred())
@@ -733,7 +733,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 					Plan: packit.BuildpackPlan{
 						Entries: tt.Entries,
 					},
-					Stack: "ubi8-paketo",
+					Stack: "io.buildpacks.stacks.ubi8",
 				})
 
 				Expect(err).To(HaveOccurred())
@@ -769,15 +769,15 @@ description = "This extension installs the appropriate nodejs runtime via dnf"
   [[metadata.dependencies]]
 	id = "node"
 	name = "Ubi Node Extension"
-	stacks = ["ubi8-paketo"]
-	source = "paketo-buildpacks/ubi8-paketo-run-nodejs-18"
+	stacks = ["io.buildpacks.stacks.ubi8"]
+	source = "paketocommunity/run-nodejs-18-ubi-base"
 	version = "18.1000"
 
   [[metadata.dependencies]]
 	id = "node"
 	name = "Ubi Node Extension"
-	stacks = ["ubi8-paketo"]
-	source = "paketo-buildpacks/ubi8-paketo-run-nodejs-16"
+	stacks = ["io.buildpacks.stacks.ubi8"]
+	source = "paketocommunity/run-nodejs-16-ubi-base"
 	version = "16.1000"
 	`
 	return fmt.Sprintf(template, version), nil


### PR DESCRIPTION
Now that it's been published, use the
https://github.com/paketo-community/ubi-base-stack instead of interim containers.

<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
Switch to ubi-base-stack now that it's been published.

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [X] I have viewed, signed, and submitted the Contributor License Agreement.
* [X] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [X] I have added an integration test, if necessary.
* [X] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [X] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
