### PR TITLE
Do not register Extensions in Buildpack registry

### DIFF
--- a/.github/workflows/push-buildpackage.yml
+++ b/.github/workflows/push-buildpackage.yml
@@ -66,14 +66,6 @@ jobs:
         echo "image=${IMAGE}" >> "$GITHUB_OUTPUT"
         echo "digest=$(sudo skopeo inspect "oci-archive:${GITHUB_WORKSPACE}/buildpackage.cnb" | jq -r .Digest)" >> "$GITHUB_OUTPUT"
 
-    - name: Register with CNB Registry
-      uses: docker://ghcr.io/buildpacks/actions/registry/request-add-entry:main
-      with:
-        id: ${{ github.repository }}
-        version: ${{ steps.event.outputs.tag_full }}
-        address: ${{ steps.push.outputs.image }}@${{ steps.push.outputs.digest }}
-        token: ${{ secrets.PAKETO_BOT_GITHUB_TOKEN }}
-
   failure:
     name: Alert on Failure
     runs-on: ubuntu-22.04


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
We asked the cnb-registry if they wanted extensions registered.. answer was no.. 

https://cloud-native.slack.com/archives/C032YE21V1T/p1689728506543929

Small change removes the registration from the workflow.

## Use Cases
Stops registering extension with registry

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
