### PR TITLE
fix: removing redundant pull policy

### DIFF
--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -59,7 +59,6 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				)
 
 				image, logs, err = pack.WithNoColor().Build.
-					WithPullPolicy("never").
 					WithExtensions(
 						settings.Buildpacks.NodeExtension.Online,
 					).
@@ -107,7 +106,6 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				)
 
 				image, logs, err = pack.WithNoColor().Build.
-					WithPullPolicy("never").
 					WithExtensions(
 						settings.Buildpacks.NodeExtension.Online,
 					).

--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -49,7 +49,6 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 
 		// var logs fmt.Stringer
 		image, _, err = pack.WithNoColor().Build.
-			WithPullPolicy("never").
 			WithExtensions(
 				settings.Buildpacks.NodeExtension.Online,
 			).

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -58,7 +58,6 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
-				WithPullPolicy("never").
 				WithExtensions(
 					settings.Buildpacks.NodeExtension.Online,
 				).

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -52,7 +52,6 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			image, logs, err = pack.WithNoColor().Build.
-				WithPullPolicy("never").
 				WithExtensions(
 					settings.Buildpacks.NodeExtension.Online,
 				).

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -68,7 +68,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
-					WithPullPolicy("never").
 					WithExtensions(
 						settings.Buildpacks.NodeExtension.Online,
 					).
@@ -166,7 +165,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
-					WithPullPolicy("never").
 					WithEnv(map[string]string{"NODE_ENV": "development", "NODE_VERBOSE": "true"}).
 					WithExtensions(
 						settings.Buildpacks.NodeExtension.Online,
@@ -250,7 +248,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
-					WithPullPolicy("never").
 					WithExtensions(
 						settings.Buildpacks.NodeExtension.Online,
 					).
@@ -347,7 +344,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 
 				var logs fmt.Stringer
 				image, logs, err = pack.WithNoColor().Build.
-					WithPullPolicy("never").
 					WithExtensions(
 						settings.Buildpacks.NodeExtension.Online,
 					).
@@ -455,7 +451,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 
 			var logs fmt.Stringer
 			_, logs, err = pack.WithNoColor().Build.
-				WithPullPolicy("never").
 				WithExtensions(
 					settings.Buildpacks.NodeExtension.Online,
 				).


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
When using extension, pull policy has to be `always`. Currently we specify both and `always` policy overlaps the `never` policy. On this pr the `never` policy is being removed and only the `always` is being kept. 

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
