### PR TITLE
"Generate phase" fetching uids and gids according to the build context

### DIFF
--- a/fakes/get_etc_passwd_file_content.go
+++ b/fakes/get_etc_passwd_file_content.go
@@ -1,0 +1,7 @@
+package fakes
+
+func Get_etc_passwd_file_content(etcPasswdFileContent string) func() (string, error) {
+	return func() (string, error) {
+		return etcPasswdFileContent, nil
+	}
+}

--- a/fakes/get_etc_passwd_file_content.go
+++ b/fakes/get_etc_passwd_file_content.go
@@ -1,7 +1,0 @@
-package fakes
-
-func Get_etc_passwd_file_content(etcPasswdFileContent string) func() (string, error) {
-	return func() (string, error) {
-		return etcPasswdFileContent, nil
-	}
-}

--- a/generate.go
+++ b/generate.go
@@ -3,7 +3,6 @@ package ubinodejsextension
 import (
 	"bytes"
 	_ "embed"
-	"errors"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -20,6 +19,9 @@ import (
 )
 
 var PACKAGES = "make gcc gcc-c++ libatomic_ops git openssl-devel nodejs npm nodejs-nodemon nss_wrapper which"
+
+var DEFAULT_USER_ID = 1001
+var DEFAULT_GROUP_ID = 1000
 
 type DuringBuildPermissions struct {
 	CNB_USER_ID, CNB_GROUP_ID int
@@ -148,9 +150,13 @@ func (d *DuringBuildPermissionsGetter) duringBuildPermissionsGetter() (DuringBui
 
 	matches := re.FindStringSubmatch(etcPasswdContent)
 
+	//In case of no cnb user in the /etc/passwd file
+	// return default values
 	if len(matches) != 3 {
-		err := errors.New("Unable to fetch user id")
-		return DuringBuildPermissions{}, err
+		return DuringBuildPermissions{
+			CNB_USER_ID:  DEFAULT_USER_ID,
+			CNB_GROUP_ID: DEFAULT_GROUP_ID,
+		}, nil
 	}
 
 	CNB_USER_ID, err := strconv.Atoi(matches[1])

--- a/generate.go
+++ b/generate.go
@@ -3,24 +3,27 @@ package ubinodejsextension
 import (
 	"bytes"
 	_ "embed"
+	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
+	"strconv"
 	"strings"
 	"text/template"
 
 	"github.com/Masterminds/semver/v3"
+	"github.com/paketo-buildpacks/libnodejs"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/paketo-buildpacks/packit/v2/draft"
-	"github.com/paketo-buildpacks/libnodejs"
 	postal "github.com/paketo-buildpacks/packit/v2/postal"
 	"github.com/paketo-buildpacks/packit/v2/scribe"
 )
 
 var PACKAGES = "make gcc gcc-c++ libatomic_ops git openssl-devel nodejs npm nodejs-nodemon nss_wrapper which"
 
-// Should be externalized
-var CNB_USER_ID = 1000
-var CNB_GROUP_ID = 1000
+type DuringBuildPermissions struct {
+	CNB_USER_ID, CNB_GROUP_ID int
+}
 
 //go:embed templates/build.Dockerfile
 var buildDockerfileTemplate string
@@ -50,8 +53,10 @@ func Generate(dependencyManager DependencyManager, logger scribe.Emitter) packit
 		logger.Title("%s %s", context.Info.Name, context.Info.Version)
 		logger.Process("Resolving Node Engine version")
 
+		duringBuildPermissions, err := GetDuringBuildPermissions(context.WorkingDir)
+
 		entryResolver := draft.NewPlanner()
-		entry, allEntries := libnodejs.ResolveNodeVersion(entryResolver.Resolve, context.Plan);
+		entry, allEntries := libnodejs.ResolveNodeVersion(entryResolver.Resolve, context.Plan)
 		if entry.Name == "" {
 			return packit.GenerateResult{}, packit.Fail.WithMessage("Node.js no longer requested by build plan")
 		}
@@ -73,29 +78,23 @@ func Generate(dependencyManager DependencyManager, logger scribe.Emitter) packit
 		// These variables have to be fetched from the env
 		CNB_STACK_ID := os.Getenv("CNB_STACK_ID")
 
-		/* Creating build.Dockerfile */
-
-		buildDockerfileProps := BuildDockerfileProps{
+		// Generating build.Dockerfile
+		buildDockerfileContent, err := FillPropsToTemplate(BuildDockerfileProps{
 			NODEJS_VERSION: NODEJS_VERSION,
-			CNB_USER_ID:    CNB_USER_ID,
-			CNB_GROUP_ID:   CNB_GROUP_ID,
+			CNB_USER_ID:    duringBuildPermissions.CNB_USER_ID,
+			CNB_GROUP_ID:   duringBuildPermissions.CNB_GROUP_ID,
 			CNB_STACK_ID:   CNB_STACK_ID,
 			PACKAGES:       "make gcc gcc-c++ libatomic_ops git openssl-devel nodejs npm nodejs-nodemon nss_wrapper which",
-		}
-
-		buildDockerfileContent, err := FillPropsToTemplate(buildDockerfileProps, buildDockerfileTemplate)
+		}, buildDockerfileTemplate)
 
 		if err != nil {
 			return packit.GenerateResult{}, err
 		}
 
-		/* Creating run.Dockerfile */
-
-		RunDockerfileProps := RunDockerfileProps{
+		// Generating run.Dockerfile
+		runDockerfileContent, err := FillPropsToTemplate(RunDockerfileProps{
 			Source: dependency.Source,
-		}
-
-		runDockerfileContent, err := FillPropsToTemplate(RunDockerfileProps, runDockerfileTemplate)
+		}, runDockerfileTemplate)
 
 		if err != nil {
 			return packit.GenerateResult{}, err
@@ -124,4 +123,41 @@ func FillPropsToTemplate(properties interface{}, templateString string) (result 
 
 	return buf.String(), nil
 
+}
+
+func GetDuringBuildPermissions(workDir string) (DuringBuildPermissions, error) {
+
+	etcPasswdFilePath := "etc/passwd"
+	re := regexp.MustCompile(`cnb:x:(\d+):(\d+)::`)
+
+	etcPasswdFile, err := os.ReadFile(filepath.Join(workDir, etcPasswdFilePath))
+	if err != nil {
+		return DuringBuildPermissions{}, err
+	}
+
+	etcPasswdContent := string(etcPasswdFile)
+
+	matches := re.FindStringSubmatch(etcPasswdContent)
+
+	if len(matches) != 3 {
+		err := errors.New("Unable to fetch user id")
+		return DuringBuildPermissions{}, err
+	}
+
+	CNB_USER_ID, err := strconv.Atoi(matches[1])
+
+	if err != nil {
+		return DuringBuildPermissions{}, err
+	}
+
+	CNB_GROUP_ID, err := strconv.Atoi(matches[2])
+
+	if err != nil {
+		return DuringBuildPermissions{}, err
+	}
+
+	return DuringBuildPermissions{
+		CNB_USER_ID:  CNB_USER_ID,
+		CNB_GROUP_ID: CNB_GROUP_ID,
+	}, nil
 }

--- a/generate.go
+++ b/generate.go
@@ -54,6 +54,9 @@ func Generate(dependencyManager DependencyManager, logger scribe.Emitter) packit
 		logger.Process("Resolving Node Engine version")
 
 		duringBuildPermissions, err := GetDuringBuildPermissions(context.WorkingDir)
+		if err != nil {
+			return packit.GenerateResult{}, err
+		}
 
 		entryResolver := draft.NewPlanner()
 		entry, allEntries := libnodejs.ResolveNodeVersion(entryResolver.Resolve, context.Plan)

--- a/generate.go
+++ b/generate.go
@@ -60,12 +60,12 @@ func NewDuringBuildPermissionsGetter(epfg EtcPasswdFileContentGetter) DuringBuil
 	return DuringBuildPermissionsGetter{get_etc_passwd_file_content: epfg}
 }
 
-func Generate(dependencyManager DependencyManager, logger scribe.Emitter, p DuringBuildPermissionsGetter) packit.GenerateFunc {
+func Generate(dependencyManager DependencyManager, logger scribe.Emitter, duringBuildPermissionsGetter DuringBuildPermissionsGetter) packit.GenerateFunc {
 	return func(context packit.GenerateContext) (packit.GenerateResult, error) {
 		logger.Title("%s %s", context.Info.Name, context.Info.Version)
 		logger.Process("Resolving Node Engine version")
 
-		duringBuildPermissions, err := p.duringBuildPermissionsGetter()
+		duringBuildPermissions, err := duringBuildPermissionsGetter.duringBuildPermissionsGetter()
 		if err != nil {
 			return packit.GenerateResult{}, err
 		}

--- a/generate.go
+++ b/generate.go
@@ -20,7 +20,7 @@ import (
 
 var PACKAGES = "make gcc gcc-c++ libatomic_ops git openssl-devel nodejs npm nodejs-nodemon nss_wrapper which"
 
-var DEFAULT_USER_ID = 1001
+var DEFAULT_USER_ID = 1002
 var DEFAULT_GROUP_ID = 1000
 
 type DuringBuildPermissions struct {

--- a/generate_test.go
+++ b/generate_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/paketo-buildpacks/packit/cargo"
 	"github.com/paketo-buildpacks/packit/v2"
 	ubinodejsextension "github.com/paketo-community/ubi-nodejs-extension"
-	"github.com/paketo-community/ubi-nodejs-extension/fakes"
 	"github.com/sclevine/spec"
 
 	"github.com/paketo-buildpacks/packit/v2/scribe"
@@ -38,6 +37,12 @@ type BuildDockerfileProps struct {
 
 //go:embed templates/build.Dockerfile
 var buildDockerfileTemplate string
+
+func mocked_get_etc_passwd_file_content(etcPasswdFileContent string) func() (string, error) {
+	return func() (string, error) {
+		return etcPasswdFileContent, nil
+	}
+}
 
 func testFillPropsToTemplate(t *testing.T, context spec.G, it spec.S) {
 
@@ -126,7 +131,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 			workingDir = t.TempDir()
 			Expect(err).NotTo(HaveOccurred())
 
-			p := ubinodejsextension.NewDuringBuildPermissionsGetter(fakes.Get_etc_passwd_file_content(`root:x:0:0:root:/root:/bin/bash
+			p := ubinodejsextension.NewDuringBuildPermissionsGetter(mocked_get_etc_passwd_file_content(`root:x:0:0:root:/root:/bin/bash
 bin:x:1:1:bin:/bin:/sbin/nologin
 daemon:x:2:2:daemon:/sbin:/sbin/nologin
 adm:x:3:4:adm:/var/adm:/sbin/nologin
@@ -175,7 +180,7 @@ cnb:x:1001:1000::/home/cnb:/bin/bash
 			workingDir = t.TempDir()
 			cnbDir, err = os.MkdirTemp("", "cnb")
 
-			p := ubinodejsextension.NewDuringBuildPermissionsGetter(fakes.Get_etc_passwd_file_content(`root:x:0:0:root:/root:/bin/bash
+			p := ubinodejsextension.NewDuringBuildPermissionsGetter(mocked_get_etc_passwd_file_content(`root:x:0:0:root:/root:/bin/bash
 bin:x:1:1:bin:/bin:/sbin/nologin
 daemon:x:2:2:daemon:/sbin:/sbin/nologin
 adm:x:3:4:adm:/var/adm:/sbin/nologin
@@ -565,7 +570,7 @@ cnb:x:1001:1000::/home/cnb:/bin/bash
 				workingDir = t.TempDir()
 				Expect(err).NotTo(HaveOccurred())
 
-				p := ubinodejsextension.NewDuringBuildPermissionsGetter(fakes.Get_etc_passwd_file_content(""))
+				p := ubinodejsextension.NewDuringBuildPermissionsGetter(mocked_get_etc_passwd_file_content(""))
 				generate = ubinodejsextension.Generate(dependencyManager, logger, p)
 
 				err = toml.NewEncoder(buf).Encode(testBuildPlan)
@@ -708,7 +713,7 @@ cnb:x:1001:1000::/home/cnb:/bin/bash
 			workingDir = t.TempDir()
 			cnbDir, err = os.MkdirTemp("", "cnb")
 
-			p := ubinodejsextension.NewDuringBuildPermissionsGetter(fakes.Get_etc_passwd_file_content(`root:x:0:0:root:/root:/bin/bash
+			p := ubinodejsextension.NewDuringBuildPermissionsGetter(mocked_get_etc_passwd_file_content(`root:x:0:0:root:/root:/bin/bash
 bin:x:1:1:bin:/bin:/sbin/nologin
 daemon:x:2:2:daemon:/sbin:/sbin/nologin
 adm:x:3:4:adm:/var/adm:/sbin/nologin

--- a/generate_test.go
+++ b/generate_test.go
@@ -38,12 +38,6 @@ type BuildDockerfileProps struct {
 //go:embed templates/build.Dockerfile
 var buildDockerfileTemplate string
 
-func mocked_get_etc_passwd_file_content(etcPasswdFileContent string) func() (string, error) {
-	return func() (string, error) {
-		return etcPasswdFileContent, nil
-	}
-}
-
 func testFillPropsToTemplate(t *testing.T, context spec.G, it spec.S) {
 
 	var (
@@ -114,20 +108,20 @@ func testFetchingPermissionsFromEtchPasswdFile(t *testing.T, context spec.G, it 
 			path = filepath.Join(tmpDir, "/passwd")
 
 			Expect(os.WriteFile(path, []byte(`root:x:0:0:root:/root:/bin/bash
-			bin:x:1:1:bin:/bin:/sbin/nologin
-			daemon:x:2:2:daemon:/sbin:/sbin/nologin
-			adm:x:3:4:adm:/var/adm:/sbin/nologin
-			lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
-			sync:x:5:0:sync:/sbin:/bin/sync
-			shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
-			halt:x:7:0:halt:/sbin:/sbin/halt
-			mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
-			operator:x:11:0:operator:/root:/sbin/nologin
-			games:x:12:100:games:/usr/games:/sbin/nologin
-			ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
-			cnb:x:1234:2345::/home/cnb:/bin/bash
-			nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin
-			`), 0600)).To(Succeed())
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+cnb:x:1234:2345::/home/cnb:/bin/bash
+nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin
+`), 0600)).To(Succeed())
 
 			duringBuilderPermissions := ubinodejsextension.GetDuringBuildPermissions(path)
 
@@ -148,19 +142,19 @@ func testFetchingPermissionsFromEtchPasswdFile(t *testing.T, context spec.G, it 
 			path = filepath.Join(tmpDir, "/passwd")
 
 			Expect(os.WriteFile(path, []byte(`root:x:0:0:root:/root:/bin/bash
-			bin:x:1:1:bin:/bin:/sbin/nologin
-			daemon:x:2:2:daemon:/sbin:/sbin/nologin
-			adm:x:3:4:adm:/var/adm:/sbin/nologin
-			lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
-			sync:x:5:0:sync:/sbin:/bin/sync
-			shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
-			halt:x:7:0:halt:/sbin:/sbin/halt
-			mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
-			operator:x:11:0:operator:/root:/sbin/nologin
-			games:x:12:100:games:/usr/games:/sbin/nologin
-			ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
-			nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin
-			`), 0600)).To(Succeed())
+bin:x:1:1:bin:/bin:/sbin/nologin
+daemon:x:2:2:daemon:/sbin:/sbin/nologin
+adm:x:3:4:adm:/var/adm:/sbin/nologin
+lp:x:4:7:lp:/var/spool/lpd:/sbin/nologin
+sync:x:5:0:sync:/sbin:/bin/sync
+shutdown:x:6:0:shutdown:/sbin:/sbin/shutdown
+halt:x:7:0:halt:/sbin:/sbin/halt
+mail:x:8:12:mail:/var/spool/mail:/sbin/nologin
+operator:x:11:0:operator:/root:/sbin/nologin
+games:x:12:100:games:/usr/games:/sbin/nologin
+ftp:x:14:50:FTP User:/var/ftp:/sbin/nologin
+nobody:x:65534:65534:Kernel Overflow User:/:/sbin/nologin
+`), 0600)).To(Succeed())
 
 			duringBuilderPermissions := ubinodejsextension.GetDuringBuildPermissions(path)
 

--- a/generate_test.go
+++ b/generate_test.go
@@ -201,7 +201,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 		err                  error
 		cnbDir               string
 		BuildDockerfileProps = ubinodejsextension.BuildDockerfileProps{
-			CNB_USER_ID:  1001,
+			CNB_USER_ID:  1002,
 			CNB_GROUP_ID: 1000,
 			CNB_STACK_ID: "",
 			PACKAGES:     ubinodejsextension.PACKAGES,
@@ -224,7 +224,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 			workingDir = t.TempDir()
 			Expect(err).NotTo(HaveOccurred())
 
-			generate = ubinodejsextension.Generate(dependencyManager, logger, ubinodejsextension.DuringBuildPermissions{CNB_USER_ID: 1001, CNB_GROUP_ID: 1000})
+			generate = ubinodejsextension.Generate(dependencyManager, logger, ubinodejsextension.DuringBuildPermissions{CNB_USER_ID: 1002, CNB_GROUP_ID: 1000})
 
 			err = toml.NewEncoder(buf).Encode(testBuildPlan)
 			Expect(err).NotTo(HaveOccurred())
@@ -258,7 +258,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 			workingDir = t.TempDir()
 			cnbDir, err = os.MkdirTemp("", "cnb")
 
-			generate = ubinodejsextension.Generate(dependencyManager, logger, ubinodejsextension.DuringBuildPermissions{CNB_USER_ID: 1001, CNB_GROUP_ID: 1000})
+			generate = ubinodejsextension.Generate(dependencyManager, logger, ubinodejsextension.DuringBuildPermissions{CNB_USER_ID: 1002, CNB_GROUP_ID: 1000})
 
 			err = toml.NewEncoder(buf).Encode(testBuildPlan)
 			Expect(err).NotTo(HaveOccurred())
@@ -710,7 +710,7 @@ func testGenerate(t *testing.T, context spec.G, it spec.S) {
 			workingDir = t.TempDir()
 			cnbDir, err = os.MkdirTemp("", "cnb")
 
-			generate = ubinodejsextension.Generate(dependencyManager, logger, ubinodejsextension.DuringBuildPermissions{CNB_USER_ID: 1001, CNB_GROUP_ID: 1000})
+			generate = ubinodejsextension.Generate(dependencyManager, logger, ubinodejsextension.DuringBuildPermissions{CNB_USER_ID: 1002, CNB_GROUP_ID: 1000})
 
 			err = toml.NewEncoder(buf).Encode(testBuildPlan)
 			Expect(err).NotTo(HaveOccurred())

--- a/init_test.go
+++ b/init_test.go
@@ -12,5 +12,6 @@ func TestUnitNode(t *testing.T) {
 	suite("Detect", testDetect)
 	suite("Generate", testGenerate)
 	suite("Dockerfile Creation", testFillPropsToTemplate)
+	suite("Fetching during build permissions", testFetchingPermissionsFromEtchPasswdFile)
 	suite.Run(t)
 }

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -70,7 +70,6 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 					WithEnv(map[string]string{
 						"BP_NODE_VERSION": "16.*.*",
 					}).
-					WithNetwork("host").
 					WithPullPolicy("always").
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -113,7 +112,6 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 					WithEnv(map[string]string{
 						"BP_NODE_VERSION": "18.*.*",
 					}).
-					WithNetwork("host").
 					WithPullPolicy("always").
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -59,7 +59,6 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 				settings.Buildpacks.Processes.Online,
 			).
 			WithEnv(map[string]string{"BP_NODE_OPTIMIZE_MEMORY": "true"}).
-			WithNetwork("host").
 			WithPullPolicy("always").
 			Execute(name, source)
 		Expect(err).NotTo(HaveOccurred(), logs.String())

--- a/integration/project_path_test.go
+++ b/integration/project_path_test.go
@@ -68,7 +68,6 @@ func testProjectPath(t *testing.T, context spec.G, it spec.S) {
 				WithEnv(map[string]string{
 					"BP_NODE_PROJECT_PATH": "hello_world_server",
 				}).
-				WithNetwork("host").
 				WithPullPolicy("always").
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -60,7 +60,6 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 					settings.Buildpacks.NodeEngine.Online,
 					settings.Buildpacks.BuildPlan.Online,
 				).
-				WithNetwork("host").
 				WithPullPolicy("always").
 				Execute(name, source)
 			Expect(err).ToNot(HaveOccurred(), logs.String)

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -77,7 +77,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 						settings.Buildpacks.BuildPlan.Online,
 					).
 					WithSBOMOutputDir(sbomDir).
-					WithNetwork("host").
 					WithPullPolicy("always").
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -170,7 +169,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 						settings.Buildpacks.NodeEngine.Online,
 						settings.Buildpacks.BuildPlan.Online,
 					).
-					WithNetwork("host").
 					WithPullPolicy("always").
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -249,7 +247,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 						settings.Buildpacks.BuildPlan.Online,
 					).
 					WithSBOMOutputDir(sbomDir).
-					WithNetwork("host").
 					WithPullPolicy("always").
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -341,7 +338,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 						settings.Buildpacks.BuildPlan.Online,
 					).
 					WithSBOMOutputDir(sbomDir).
-					WithNetwork("host").
 					WithPullPolicy("always").
 					Execute(name, source)
 				Expect(err).ToNot(HaveOccurred(), logs.String)
@@ -444,7 +440,6 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				).
 				WithEnv(map[string]string{"BP_NODE_VERSION": "~14"}).
 				WithSBOMOutputDir(sbomDir).
-				WithNetwork("host").
 				WithPullPolicy("always").
 				Execute(name, source)
 

--- a/run/main.go
+++ b/run/main.go
@@ -14,9 +14,10 @@ import (
 func main() {
 	dependencyManager := postal.NewService(cargo.NewTransport())
 	logEmitter := scribe.NewEmitter(os.Stdout).WithLevel(os.Getenv("BP_LOG_LEVEL"))
+	p := ubinodejsextension.NewDuringBuildPermissionsGetter(ubinodejsextension.Get_etc_passwd_file_content)
 
 	packit.RunExtension(
 		ubinodejsextension.Detect(),
-		ubinodejsextension.Generate(dependencyManager, logEmitter),
+		ubinodejsextension.Generate(dependencyManager, logEmitter, p),
 	)
 }

--- a/run/main.go
+++ b/run/main.go
@@ -14,10 +14,10 @@ import (
 func main() {
 	dependencyManager := postal.NewService(cargo.NewTransport())
 	logEmitter := scribe.NewEmitter(os.Stdout).WithLevel(os.Getenv("BP_LOG_LEVEL"))
-	duringBuildPermissionsGetter := ubinodejsextension.NewDuringBuildPermissionsGetter(ubinodejsextension.Get_etc_passwd_file_content)
+	duringBuildPermissions := ubinodejsextension.GetDuringBuildPermissions("/etc/passwd")
 
 	packit.RunExtension(
 		ubinodejsextension.Detect(),
-		ubinodejsextension.Generate(dependencyManager, logEmitter, duringBuildPermissionsGetter),
+		ubinodejsextension.Generate(dependencyManager, logEmitter, duringBuildPermissions),
 	)
 }

--- a/run/main.go
+++ b/run/main.go
@@ -14,10 +14,10 @@ import (
 func main() {
 	dependencyManager := postal.NewService(cargo.NewTransport())
 	logEmitter := scribe.NewEmitter(os.Stdout).WithLevel(os.Getenv("BP_LOG_LEVEL"))
-	p := ubinodejsextension.NewDuringBuildPermissionsGetter(ubinodejsextension.Get_etc_passwd_file_content)
+	duringBuildPermissionsGetter := ubinodejsextension.NewDuringBuildPermissionsGetter(ubinodejsextension.Get_etc_passwd_file_content)
 
 	packit.RunExtension(
 		ubinodejsextension.Detect(),
-		ubinodejsextension.Generate(dependencyManager, logEmitter, p),
+		ubinodejsextension.Generate(dependencyManager, logEmitter, duringBuildPermissionsGetter),
 	)
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->
## Merge After
* https://github.com/paketo-community/ubi-nodejs-extension/pull/25

## Summary
<!-- A short explanation of the proposed change -->
During the generate phase, we build the `build` and the `run` image for the  build phase and for the runtime. At the moment, the uid and gid of the `build` and `run` image are hardcoded inside the `/bin/generate` https://github.com/paketo-community/ubi-nodejs-extension/blob/7caa04ee9a7e22dd1948c62fcaca03679be0db99/generate.go#L22-L23 A Better approach is to let generate phase propagate on the `build` and `run` images, the uid and gid that the `cnb` user has on the current context that the app is being built. This approach is preferable as it also matches the uid and gids we specify on this PR https://github.com/paketo-community/ubi-base-stack/pull/22   

The implementation of this pr is as follows:
* Instead of having hardcoded the values of `uids` and `gids` inside the `generate` binary, we fetch the `uid` and `gid` of the cnb user from the `etc/passwd` file. 

## Use Cases
<!-- An explanation of the use cases your change enables -->

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have added an integration test, if necessary.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
