### PR TITLE
Removing functionality that conditionally providing Node.js

### DIFF
--- a/detect.go
+++ b/detect.go
@@ -1,41 +1,11 @@
 package ubinodejsextension
 
 import (
-	"os"
-	"path/filepath"
-
-	"github.com/paketo-buildpacks/libnodejs"
 	"github.com/paketo-buildpacks/packit/v2"
 )
 
 func Detect() packit.DetectFunc {
 	return func(context packit.DetectContext) (packit.DetectResult, error) {
-		// likely move these to main.go ?
-		workingDir := context.WorkingDir
-
-		projectPath, err := libnodejs.FindProjectPath(context.WorkingDir)
-		if err != nil {
-			return packit.DetectResult{}, err
-		}
-
-		pkg, err := libnodejs.ParsePackageJSON(filepath.Join(projectPath))
-		if err != nil && !os.IsNotExist(err) {
-			return packit.DetectResult{}, packit.Fail
-		}
-
-		if err != nil || !pkg.HasStartScript() {
-			// no package.json so look for Node.js application files
-			path, err := libnodejs.FindNodeApplication(workingDir)
-			if err != nil {
-				return packit.DetectResult{}, err
-			}
-			// if no application was found then we don't need to provide node
-			if path == "" {
-				return packit.DetectResult{}, packit.Fail.WithMessage("Not a Node.js application")
-			}
-		}
-
-		// if we get here we either found a pacakge.json or Node.js application file
 		return packit.DetectResult{
 			Plan: packit.BuildPlan{
 				Provides: []packit.BuildPlanProvision{

--- a/detect_test.go
+++ b/detect_test.go
@@ -5,10 +5,6 @@ import (
 
 	ubinodejsextension "github.com/paketo-community/ubi-nodejs-extension"
 
-	//	"github.com/paketo-buildpacks/packit/v2"
-	"os"
-	"path/filepath"
-
 	. "github.com/onsi/gomega"
 	"github.com/paketo-buildpacks/packit/v2"
 	"github.com/sclevine/spec"
@@ -28,224 +24,19 @@ var expectedDetectBuildPlan packit.BuildPlan = packit.BuildPlan{
 	},
 }
 
-var expectedNotDetectBuildPlan packit.BuildPlan = packit.BuildPlan{
-	Provides: nil,
-}
-
 func testDetect(t *testing.T, context spec.G, it spec.S) {
 
 	var (
-		Expect        = NewWithT(t).Expect
-		workingDir    string
-		detectContext packit.DetectContext
-		err           error
-		detectResult  packit.DetectResult
+		Expect       = NewWithT(t).Expect
+		err          error
+		detectResult packit.DetectResult
 	)
 
-	context("when no application is detected", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
+	it("it returns a plan that provides node and/or npm", func() {
+		detectResult, err = ubinodejsextension.Detect()(packit.DetectContext{
+			WorkingDir: "/working-dir",
 		})
-
-		it("indicates it does not participate", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).To(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedNotDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when an application is auto detected in the default working dir", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			Expect(os.WriteFile(filepath.Join(workingDir, "server.js"), nil, 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("detects", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when an application is auto detected in directory set by BP_NODE_PROJECT_PATH", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			t.Setenv("BP_NODE_PROJECT_PATH", "./src")
-			Expect(os.MkdirAll(filepath.Join(workingDir, "src"), os.ModePerm)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "src", "server.js"), nil, 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("detects", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when an application is detected based on BP_LAUNCHPOINT in the default working dir", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			t.Setenv("BP_LAUNCHPOINT", "not_a_known_name.js")
-			Expect(os.WriteFile(filepath.Join(workingDir, "not_a_known_name.js"), nil, 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("detects", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when an application is detected based on BP_LAUNCHPOINT in directory set by BP_NODE_PROJECT_PATH", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			t.Setenv("BP_NODE_PROJECT_PATH", "./src")
-			t.Setenv("BP_LAUNCHPOINT", "./src/not_a_known_name.js")
-			Expect(os.MkdirAll(filepath.Join(workingDir, "src"), os.ModePerm)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "src", "not_a_known_name.js"), nil, 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("detects", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when there is a package.json without a start script and no application", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			Expect(os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
-				"scripts": {
-						"prestart":  "npm run lint",
-						"poststart": "npm run test"
-				}
-			}`), 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("indicates it does not participate", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).To(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedNotDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when there is a package.json with start script in default directory", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			Expect(os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
-				"scripts": {
-						"start":  "node server.js"
-				}
-			}`), 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("detects", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when there is a package.json with start script in BP_NODE_PROJECT_PATH", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			t.Setenv("BP_NODE_PROJECT_PATH", "./src")
-			Expect(os.MkdirAll(filepath.Join(workingDir, "src"), os.ModePerm)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "src", "package.json"), []byte(`{
-				"scripts": {
-						"start":  "node server.js"
-				}
-			}`), 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("detects", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
-	context("when there is a package.json without a start script, with application", func() {
-		it.Before(func() {
-			workingDir = t.TempDir()
-			Expect(os.WriteFile(filepath.Join(workingDir, "package.json"), []byte(`{
-				"scripts": {
-						"prestart":  "npm run lint",
-						"poststart": "npm run test"
-				}
-			}`), 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "server.js"), []byte(`dummy`), 0600)).To(Succeed())
-			Expect(os.WriteFile(filepath.Join(workingDir, "plan"), nil, 0600)).To(Succeed())
-
-			err = os.Chdir(workingDir)
-			Expect(err).NotTo(HaveOccurred())
-			detectContext = packit.DetectContext{
-				WorkingDir: workingDir,
-			}
-		})
-
-		it("detects", func() {
-			detectResult, err = ubinodejsextension.Detect()(detectContext)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
-		})
-	}, spec.Sequential())
-
+		Expect(err).NotTo(HaveOccurred())
+		Expect(detectResult.Plan).To(Equal(expectedDetectBuildPlan))
+	})
 }


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR removes the functionality that provides Node.js and npm conditionally. Similar to what node-engine buildpack does, ubi-nodejs-extension on this PR will always provides Node.js and npm  

## Use Cases
<!-- An explanation of the use cases your change enables -->
* No matter the folder structure of the app, it will provide Node.js and npm.

## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [ ] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
