### PR TITLE
fix: integration tests, node home validation should be empty string

### DIFF
--- a/integration/init_test.go
+++ b/integration/init_test.go
@@ -96,10 +96,10 @@ func TestIntegration(t *testing.T) {
 	SetDefaultEventuallyTimeout(5 * time.Second)
 
 	suite := spec.New("Integration", spec.Report(report.Terminal{}), spec.Parallel())
+	suite("OpenSSL", testOpenSSL)
 	suite("OptimizeMemory", testOptimizeMemory)
 	suite("ProjectPath", testProjectPath)
 	suite("Provides", testProvides)
 	suite("Simple", testSimple)
-	suite("OpenSSL", testOpenSSL)
 	suite.Run(t)
 }

--- a/integration/openssl_test.go
+++ b/integration/openssl_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -87,7 +86,7 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					`[extender (build)]   Configuring launch environment`,
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -129,7 +128,7 @@ func testOpenSSL(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					`[extender (build)]   Configuring launch environment`,
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))

--- a/integration/optimize_memory_test.go
+++ b/integration/optimize_memory_test.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"testing"
 
 	"github.com/paketo-buildpacks/occam"
@@ -77,7 +76,7 @@ func testOptimizeMemory(t *testing.T, context spec.G, it spec.S) {
 		Expect(logs).To(ContainLines(
 			`[extender (build)]   Configuring launch environment`,
 			`[extender (build)]     NODE_ENV        -> "production"`,
-			fmt.Sprintf(`[extender (build)]     NODE_HOME       -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+			`[extender (build)]     NODE_HOME       -> ""`,
 			`[extender (build)]     NODE_OPTIONS    -> "--use-openssl-ca"`,
 			`[extender (build)]     NODE_VERBOSE    -> "false"`,
 			`[extender (build)]     OPTIMIZE_MEMORY -> "true"`,

--- a/integration/provides_test.go
+++ b/integration/provides_test.go
@@ -83,7 +83,7 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				"[extender (build)]   Configuring build environment",
 				`[extender (build)]     NODE_ENV     -> "production"`,
-				fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				`[extender (build)]     NODE_HOME    -> ""`,
 				`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 				`[extender (build)]     NODE_VERBOSE -> "false"`,
 			))
@@ -91,7 +91,7 @@ func testProvides(t *testing.T, context spec.G, it spec.S) {
 			Expect(logs).To(ContainLines(
 				`[extender (build)]   Configuring launch environment`,
 				`[extender (build)]     NODE_ENV     -> "production"`,
-				fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+				`[extender (build)]     NODE_HOME    -> ""`,
 				`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 				`[extender (build)]     NODE_VERBOSE -> "false"`,
 			))

--- a/integration/simple_app_test.go
+++ b/integration/simple_app_test.go
@@ -101,7 +101,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					"[extender (build)]   Configuring build environment",
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -109,7 +109,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					`[extender (build)]   Configuring launch environment`,
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -176,7 +176,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					"[extender (build)]   Configuring build environment",
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -184,7 +184,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					`[extender (build)]   Configuring launch environment`,
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -270,7 +270,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					"[extender (build)]   Configuring build environment",
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -278,7 +278,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					`[extender (build)]   Configuring launch environment`,
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -361,7 +361,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					"[extender (build)]   Configuring build environment",
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))
@@ -369,7 +369,7 @@ func testSimple(t *testing.T, context spec.G, it spec.S) {
 				Expect(logs).To(ContainLines(
 					`[extender (build)]   Configuring launch environment`,
 					`[extender (build)]     NODE_ENV     -> "production"`,
-					fmt.Sprintf(`[extender (build)]     NODE_HOME    -> "/layers/%s/node"`, strings.ReplaceAll(settings.Buildpack.ID, "/", "_")),
+					`[extender (build)]     NODE_HOME    -> ""`,
 					`[extender (build)]     NODE_OPTIONS -> "--use-openssl-ca"`,
 					`[extender (build)]     NODE_VERBOSE -> "false"`,
 				))


### PR DESCRIPTION
<!-- Thanks for contributing. To speed up the process of reviewing your pull
request please provide us with the following information: -->

## Summary
<!-- A short explanation of the proposed change -->
This PR fixes integration tests as after changing the `NODE_HOME` env variable on node-engine to be an emtpy string https://github.com/paketo-buildpacks/node-engine/pull/785 integration tets are failing.

### This PR also fixes below PRs
* https://github.com/paketo-community/ubi-nodejs-extension/pull/83
* https://github.com/paketo-community/ubi-nodejs-extension/pull/80

## Use Cases
<!-- An explanation of the use cases your change enables -->
* Fixes integration tests

## After merging it:
* Cut a release
* Close this issue https://github.com/paketo-community/ubi-nodejs-extension/issues/27


## Checklist
<!-- Please confirm the following -->
* [x] I have viewed, signed, and submitted the Contributor License Agreement.
* [x] I have linked issue(s) that this PR should close using keywords or the Github UI (See [docs](https://docs.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue))
* [x] I have added an integration test, if necessary.
* [x] I have reviewed the [styleguide](https://github.com/paketo-buildpacks/community/blob/main/STYLEGUIDE.md) for guidance on my code quality.
* [x] I'm happy with the commit history on this PR (I have rebased/squashed as needed).
